### PR TITLE
adding --repeat to the pep8 tasks 

### DIFF
--- a/armstrong/dev/tasks/__init__.py
+++ b/armstrong/dev/tasks/__init__.py
@@ -96,7 +96,7 @@ def command(*cmds):
 @task
 def pep8():
     """Run pep8 on all .py files in ./armstrong"""
-    local('find ./armstrong -name "*.py" | xargs pep8', capture=False)
+    local('find ./armstrong -name "*.py" | xargs pep8 --repeat', capture=False)
 
 
 @task


### PR DESCRIPTION
pep 8 problems were being obscured by previous errors of the same type. adding --repeat tells pep8 to display repeats.
