### PR TITLE
Add support for using ENV to adjust test environment

### DIFF
--- a/armstrong/dev/tasks/__init__.py
+++ b/armstrong/dev/tasks/__init__.py
@@ -41,7 +41,7 @@ def pip_install(func):
     def inner(*args, **kwargs):
         if getattr(fabfile, "pip_install_first", True):
             with settings(warn_only=True):
-                if not os.environ.get("SKIP_INSTALL", True):
+                if not os.environ.get("SKIP_INSTALL", False):
                     local("pip uninstall -y %s" % get_full_name(), capture=False)
                     local("pip install .", capture=False)
         func(*args, **kwargs)


### PR DESCRIPTION
In a CI environment, we generally don't need to do a re-install and sometimes we can't build code coverage graphs.  This allows both of those to be turned off with the following environment variables:
- `SKIP_INSTALL`
- `SKIP_COVERAGE`
