### PR TITLE
Add `assertInContext` method.

### DIFF
--- a/armstrong/dev/tests/utils/base.py
+++ b/armstrong/dev/tests/utils/base.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
     from .backports import override_settings
 
+
 class ArmstrongTestCase(DjangoTestCase):
     def setUp(self):
         fudge.clear_expectations()
@@ -45,6 +46,13 @@ class ArmstrongTestCase(DjangoTestCase):
             msg = "%s.%s is not a %s" % (model.__class__.__name__, field_name,
                     field_class.__class__.__name__)
             self.assertTrue(isinstance(field, field_class), msg=msg)
+
+    def assertInContext(self, var_name, other, template_or_context):
+        # TODO: support passing in a straight "context" (i.e., dict)
+        context = template_or_context.context_data
+        self.assertTrue(var_name in context,
+                msg="`%s` not in provided context" % var_name)
+        self.assertEqual(context[var_name], other)
 
     def assertNone(self, obj, **kwargs):
         self.assertTrue(obj is None, **kwargs)


### PR DESCRIPTION
This is being promoted from its [former life](https://github.com/armstrong/armstrong.core.arm_wells/blob/42970c05a7c7981dc5644285fda23c9d33409b6d/armstrong/core/arm_wells/tests/_utils.py#L28-33) in `arm_wells.tests._utils.py.TestCase`.

Let me know if `assertInContext` is used anywhere else.
