### PR TITLE
Adjust the settings reset to work with Django 1.4

### DIFF
--- a/armstrong/dev/virtualdjango/base.py
+++ b/armstrong/dev/virtualdjango/base.py
@@ -1,3 +1,4 @@
+import django
 import os, sys
 
 DEFAULT_SETTINGS = {
@@ -25,8 +26,17 @@ class VirtualDjango(object):
 
         settings = self.settings
         if reset:
-            settings._wrapped = None
+            self.reset_settings(settings)
         settings.configure(**custom_settings)
+
+    def reset_settings(self, settings):
+        if django.VERSION[:2] == (1, 3):
+            settings._wrapped = None
+            return
+
+        # This is the way to reset settings going forward
+        from django.utils.functional import empty
+        settings._wrapped = empty
         
     @property
     def settings(self):


### PR DESCRIPTION
Django changed the `settings._wrapped` value from `None` to the special
`empty` object.  This change maintains backwards compatibility for 1.3.X,
while using the new method for all other versions of Django.
