### PR TITLE
refactor `coverage` task

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 CHANGES
 =======
 
+2.1.0 (unreleased)
+------------------
+
+- **Backward incompatible:** Drop the COVERAGE_EXCLUDE_FILES setting
+  introduced in 2.0. Better to use the more universal .coveragerc file.
+
+- Coverage task no longer sets branch, source and omit options. Not
+  duplicating those across Armstrong components was nice but using a
+  .coveragerc file is standard and will work more flexibly no matter
+  how Coverage is run.
+
 2.0.0 (2014-04-01)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -25,11 +25,6 @@ and Tox will complete ASAP.
 Many of the Invoke tasks have their own package requirements and they will
 nicely notify you if something they require needs to be installed.
 
-**Optional Settings:** (Used in ``env_settings.py``)
-
-``COVERAGE_EXCLUDE_FILES = ['*/migrations/*']``
-  A list of filename patterns for files to exclude during coverage testing.
-  Individual components are free to extend or replace this setting.
 
 .. _Invoke: http://docs.pyinvoke.org/en/latest/index.html
 
@@ -64,7 +59,8 @@ Two general rules: 1) enclose multiple args in quotes 2) kwargs need to use
 ``invoke coverage [--reportdir=<directory>] [--extra ...]``
   for running test coverage. --extra works the same as in "invoke test" passing
   arbitrary args to the underlying test command. --reportdir is where the HTML
-  report will be created; by default this directory is named "coverage".
+  report will be created; by default this directory is named "htmlcov" or
+  whatever is set in the ``.coveragerc`` file.
 
 ``invoke managepy <cmd> [--extra ...]``
   to run any Django "manage.py" command where --extra handles any arbitrary

--- a/armstrong/dev/default_settings.py
+++ b/armstrong/dev/default_settings.py
@@ -29,8 +29,6 @@ DATABASES = {
 }
 TEST_RUNNER = "armstrong.dev.tests.runner.ArmstrongDiscoverRunner"
 
-COVERAGE_EXCLUDE_FILES = ['*/migrations/*']
-
 # Add a DEBUG console "armstrong" logger
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
It's simpler now. Instead of setting branch/source/omit in our custom code, each component will need a `.coveragerc` file. This requires some duplication across components, but very minimal. I think the gains are worth it:
- one place for any Coverage setting
- works for any way you run Coverage
